### PR TITLE
Fix code scanning alert no. 1: Incorrect conversion between integer types

### DIFF
--- a/keygen/keygen.go
+++ b/keygen/keygen.go
@@ -28,17 +28,18 @@ func main() {
 		fmt.Println("Usage: keygen [netkey]")
 		return
 	}
-	netkey, err := strconv.Atoi(os.Args[1])
+	netkey, err := strconv.ParseUint(os.Args[1], 10, 8)
 	if err != nil {
 		log.Fatal(err)
 	}
+	netkeyByte := byte(netkey)
 
 	pub, priv, err := NewKey()
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	addr := EncodeAddress(hash160(pub), byte(netkey))
+	addr := EncodeAddress(hash160(pub), netkeyByte)
 	fmt.Println("addr:", addr)
 	fmt.Println("pubk:", hex.EncodeToString(pub))
 	fmt.Println("priv:", hex.EncodeToString(priv))


### PR DESCRIPTION
Fixes [https://github.com/Dargon789/btcutils/security/code-scanning/1](https://github.com/Dargon789/btcutils/security/code-scanning/1)

To fix the problem, we need to ensure that the value of `netkey` is within the valid range for a `byte` (0 to 255) before performing the conversion. This can be achieved by using `strconv.ParseUint` with a bit size of 8, which directly parses the string into a `uint8` value. This approach avoids the need for additional bounds checking and ensures that the conversion is safe.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Fix incorrect conversion between integer types by using strconv.ParseUint to safely parse netkey as a uint8 value.